### PR TITLE
Add Circle CI config for running unittests and badge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/postgres:9.6
+        environment:
+          POSTGRES_USER: olat
+          POSTGRES_PASSWORD: olat
+          POSTGRES_DB: olattest
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m -Xms1024m 
+    
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+        
+      # run tests!
+      - run: mvn test -Dwith-postgresql -Dtest.env.db.postgresql.user=olat -Dtest.env.db.postgresql.pass=olat -Dtest=org.olat.test.AllTestsJunit4 -Ptomcat
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk
+        environment:
+          TZ: "Europe/Zurich"
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -17,15 +19,20 @@ jobs:
           POSTGRES_USER: olat
           POSTGRES_PASSWORD: olat
           POSTGRES_DB: olattest
+          TZ: "Europe/Zurich"
 
     working_directory: ~/repo
 
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m -Xms1024m 
+      MAVEN_OPTS: -Xmx3200m -Xms1024m
+      TZ: "Europe/Zurich"
     
     steps:
       - checkout
+
+      # Set timezone
+      - run: sudo ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ | sudo tee /etc/timezone
 
       # Download and cache dependencies
       - restore_cache:
@@ -36,11 +43,11 @@ jobs:
 
       - run: mvn dependency:go-offline
 
+      # run tests!
+      - run: mvn test -q -Dwith-postgresql -Dtest.env.db.postgresql.user=olat -Dtest.env.db.postgresql.pass=olat -Dtest=org.olat.test.AllTestsJunit4 -Ptomcat
+
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-        
-      # run tests!
-      - run: mvn test -Dwith-postgresql -Dtest.env.db.postgresql.user=olat -Dtest.env.db.postgresql.pass=olat -Dtest=org.olat.test.AllTestsJunit4 -Ptomcat
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ src/test/java/org/olat/selenium/SeleniumTest.java
 
 */.project
 .idea
-

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 A sophisticated modular toolkit provides course authors with a wide range of didactic possibilities. Each OpenOLAT installation can be individually extended, adapted to organizational needs, and integrated into existing IT infrastructures. The architecture is designed for minimal resource consumption, scalability and security in order to guarantee high system reliability.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CircleCI](https://circleci.com/gh/OpenOLAT/OpenOLAT.svg?style=svg)](https://circleci.com/gh/OpenOLAT/OpenOLAT)
 
 ## Table of Contents
 
@@ -444,4 +445,5 @@ The following features are delegated to the application server
 | x | LDAP Connection |
 | OK | Hibernate/JPA (only JBoss AS, we depend on Hibernate) |
 | OK | Caching (for JPA second level cache for example) |
+
 


### PR DESCRIPTION
Make sure this is merged BEFORE the repository is activated on Circle CI. Otherwise it is initialized with the obsolete 1.0 format of Circle CI.

On current master there is one unittest failing: `ICalFileCalendarManagerTest.testImportICal_outlookFullDay:662`