### PR TITLE
Add logout listener

### DIFF
--- a/src/main/java/ch/uzh/lms/listener/LogoutListener.java
+++ b/src/main/java/ch/uzh/lms/listener/LogoutListener.java
@@ -1,0 +1,22 @@
+package ch.uzh.lms.listener;
+
+import org.olat.core.gui.UserRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class can be extended to run code when the user logs out of OLAT.
+ *
+ * @author Christian Schweizer (christian.schweizer3@uzh.ch)
+ */
+@Component
+public class LogoutListener {
+
+    /**
+     * This method will be executed when the user logs out of OLAT.
+     *
+     * @param userRequest The user request
+     */
+    public void onLogout(UserRequest userRequest) {
+        // Do nothing here
+    }
+}

--- a/src/main/java/org/olat/_spring/mainContext.xml
+++ b/src/main/java/org/olat/_spring/mainContext.xml
@@ -9,7 +9,7 @@
         http://www.springframework.org/schema/context/spring-context.xsd">
   
 	<context:property-placeholder location="classpath:serviceconfig/olat.properties, classpath:olat.local.properties" system-properties-mode="OVERRIDE"/>
-	<context:component-scan base-package="org.olat.basesecurity,org.olat.note,org.olat.social,org.olat.commons.memberlist,org.olat.commons.info" />
+	<context:component-scan base-package="org.olat.basesecurity,org.olat.note,org.olat.social,org.olat.commons.memberlist,org.olat.commons.info,ch.uzh.lms.listener" />
 	<context:annotation-config />
 
 	<import resource="classpath:/org/olat/core/_spring/mainCorecontext.xml"/>

--- a/src/main/java/org/olat/gui/control/OlatGuestTopNavController.java
+++ b/src/main/java/org/olat/gui/control/OlatGuestTopNavController.java
@@ -25,6 +25,7 @@
 
 package org.olat.gui.control;
 
+import ch.uzh.lms.listener.LogoutListener;
 import org.olat.admin.user.tools.UserTool;
 import org.olat.basesecurity.AuthHelper;
 import org.olat.core.CoreSpringFactory;
@@ -64,7 +65,10 @@ public class OlatGuestTopNavController extends BasicController implements Lockab
 	private SearchModule searchModule;
 	@Autowired
 	private ImpressumModule impressumModule;
-	
+
+	@Autowired
+	private LogoutListener[] logoutListeners;
+
 	public OlatGuestTopNavController(UserRequest ureq, WindowControl wControl) {
 		super(ureq, wControl);
 		VelocityContainer vc = createVelocityContainer("guesttopnav");
@@ -114,6 +118,9 @@ public class OlatGuestTopNavController extends BasicController implements Lockab
 	public void event(UserRequest ureq, Component source, Event event) {
 		if (source == loginLink) {
 			AuthHelper.doLogout(ureq);
+			for (LogoutListener logoutListener : logoutListeners) {
+				logoutListener.onLogout(ureq);
+			}
 		} else if (source == impressumLink) {
 			ControllerCreator impressumControllerCreator = new ControllerCreator() {
 				@Override

--- a/src/main/java/org/olat/gui/control/UserToolsMenuController.java
+++ b/src/main/java/org/olat/gui/control/UserToolsMenuController.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import ch.uzh.lms.listener.LogoutListener;
 import org.olat.admin.user.tools.UserTool;
 import org.olat.admin.user.tools.UserToolCategory;
 import org.olat.admin.user.tools.UserToolExtension;
@@ -57,6 +58,9 @@ public class UserToolsMenuController extends BasicController implements Lockable
 	
 	@Autowired
 	private UserToolsModule userToolsModule;
+
+	@Autowired
+	private LogoutListener[] logoutListeners;
 	
 	public UserToolsMenuController(UserRequest ureq, WindowControl wControl) {
 		super(ureq, wControl);
@@ -140,6 +144,9 @@ public class UserToolsMenuController extends BasicController implements Lockable
 			String command = event.getCommand();
 			if (command.equals(ACTION_LOGOUT)) {
 				AuthHelper.doLogout(ureq);
+				for (LogoutListener logoutListener : logoutListeners) {
+					logoutListener.onLogout(ureq);
+				}
 			}
 		}
 	}

--- a/src/test/java/ch/uzh/lms/listener/PrintingOnLogoutListener.java
+++ b/src/test/java/ch/uzh/lms/listener/PrintingOnLogoutListener.java
@@ -1,0 +1,14 @@
+package ch.uzh.lms.listener;
+
+import org.olat.core.gui.UserRequest;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class PrintingOnLogoutListener extends LogoutListener {
+
+    @Override
+    public void onLogout(UserRequest userRequest) {
+        System.out.print("hello listener");
+    }
+}

--- a/src/test/java/org/olat/gui/control/UserToolsMenuControllerTest.java
+++ b/src/test/java/org/olat/gui/control/UserToolsMenuControllerTest.java
@@ -1,0 +1,54 @@
+package org.olat.gui.control;
+
+import ch.uzh.lms.listener.LogoutListener;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.olat.core.gui.UserRequest;
+import org.olat.core.gui.components.panel.SimpleStackedPanel;
+import org.olat.core.gui.control.Event;
+import org.olat.core.gui.control.WindowControl;
+import org.olat.core.gui.util.SyntheticUserRequest;
+import org.olat.test.OlatTestCase;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Locale;
+
+import static org.mockito.Mockito.mock;
+
+
+public class UserToolsMenuControllerTest extends OlatTestCase {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @After
+    public void restoreStreams() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    public void logout_listener() {
+        UserRequest req = new SyntheticUserRequest(null, Locale.ENGLISH);
+        WindowControl wControl = mock(WindowControl.class);
+
+        UserToolsMenuController utmc = new UserToolsMenuController(req, wControl);
+
+        Event ev = new Event("logout");
+        SimpleStackedPanel ssp = (SimpleStackedPanel) utmc.getInitialComponent();
+
+        // we set the request to null here on purpose. In this case the AuthHelper.doLogout
+        // returns immediately and we can test the logout listener
+        utmc.dispatchEvent(null,  ssp.getContent(), ev);
+        Assert.assertEquals("hello listener", outContent.toString());
+    }
+}


### PR DESCRIPTION
This PR adds a logout listener to OpenOlat. It can be used to hook custom actions on logout, which we do @ UZH