### PR TITLE
Unify getting roles for footer and topnav part

### DIFF
--- a/src/main/java/org/olat/gui/control/OlatFooterController.java
+++ b/src/main/java/org/olat/gui/control/OlatFooterController.java
@@ -48,6 +48,7 @@ import org.olat.core.gui.control.creator.ControllerCreator;
 import org.olat.core.gui.control.generic.popup.PopupBrowserWindow;
 import org.olat.core.helpers.Settings;
 import org.olat.core.id.Identity;
+import org.olat.core.id.Roles;
 import org.olat.core.util.StringHelper;
 import org.olat.core.util.UserSession;
 import org.olat.core.util.Util;
@@ -90,11 +91,19 @@ public class OlatFooterController extends BasicController implements LockableCon
 
 		olatFootervc = createVelocityContainer("olatFooter");
 
-		Identity identity = ureq.getIdentity();
+		boolean isGuest;
+		boolean isInvitee;
 		UserSession usess = ureq.getUserSession();
-		boolean isGuest = (identity == null ? true : usess.getRoles().isGuestOnly());
-		boolean isInvitee = (identity == null ? false : usess.getRoles().isInvitee());
-		
+		if (getIdentity() != null) {
+			Roles roles = usess.getRoles();
+			isGuest = (roles == null ? true : roles.isGuestOnly());
+			isInvitee = (roles == null ? false : roles.isInvitee());
+
+		} else {
+			isGuest = true;
+			isInvitee = false;
+		}
+
 		// Show user count
 		UserLoggedInCounter userCounter = new UserLoggedInCounter();
 		olatFootervc.put("userCounter", userCounter);
@@ -117,10 +126,10 @@ public class OlatFooterController extends BasicController implements LockableCon
 		if (!isGuest && usess.isAuthenticated()) {
 			olatFootervc.contextPut("loggedIn", Boolean.TRUE);
 			if(isInvitee) {
-				String fullName = CoreSpringFactory.getImpl(UserManager.class).getUserDisplayName(ureq.getIdentity());
+				String fullName = CoreSpringFactory.getImpl(UserManager.class).getUserDisplayName(getIdentity());
 				olatFootervc.contextPut("username", StringHelper.escapeHtml(fullName) + " " + translate("logged.in.invitee"));
 			} else {
-				String fullName = CoreSpringFactory.getImpl(UserManager.class).getUserDisplayName(ureq.getIdentity());
+				String fullName = CoreSpringFactory.getImpl(UserManager.class).getUserDisplayName(getIdentity());
 				olatFootervc.contextPut("username", StringHelper.escapeHtml(fullName));
 			}
 		} else {

--- a/src/main/java/org/olat/gui/control/OlatTopNavController.java
+++ b/src/main/java/org/olat/gui/control/OlatTopNavController.java
@@ -43,6 +43,7 @@ import org.olat.core.id.Roles;
 import org.olat.core.id.User;
 import org.olat.core.id.UserConstants;
 import org.olat.core.util.StringHelper;
+import org.olat.core.util.UserSession;
 import org.olat.core.util.prefs.Preferences;
 import org.olat.user.DisplayPortraitController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,21 +67,30 @@ public class OlatTopNavController extends BasicController implements LockableCon
 		super(ureq, wControl);
 		topNavVC = createVelocityContainer("topnav");
 		topNavVC.setDomReplacementWrapperRequired(false); // we provide our own DOM replacmenet ID
-		
-		Roles roles = ureq.getUserSession().getRoles();
-		boolean isGuest = roles.isGuestOnly();
-		boolean isInvitee = roles.isInvitee();
-		topNavVC.contextPut("isGuest", new Boolean(isGuest));
-		topNavVC.contextPut("isInvitee", new Boolean(isInvitee));
+
+		boolean isGuest;
+		boolean isInvitee;
+		UserSession usess = ureq.getUserSession();
+		if (getIdentity() != null) {
+			Roles roles = usess.getRoles();
+			isGuest = (roles == null ? true : roles.isGuestOnly());
+			isInvitee = (roles == null ? false : roles.isInvitee());
+
+		} else {
+			isGuest = true;
+			isInvitee = false;
+		}
+		topNavVC.contextPut("isGuest", isGuest);
+		topNavVC.contextPut("isInvitee", isInvitee);
 		
 		// login link
-		if (ureq.getIdentity() == null) {
+		if (getIdentity() == null) {
 			loginLink = LinkFactory.createLink("topnav.login", topNavVC, this);
 			loginLink.setIconLeftCSS("o_icon o_icon_login o_icon-lg");
 			loginLink.setTooltip("topnav.login.alt");
 		}
 		
-		if(ureq.getIdentity() != null && !isGuest && !isInvitee) {
+		if(getIdentity() != null && !isGuest && !isInvitee) {
 			loadPersonalTools(ureq);
 			
 			// the user profile


### PR DESCRIPTION
Both topnav and footer gets the roles from the user to manage the display of certain aspects.

This PR does two things:

1. Use the same implementation for both places. (Would putting this in a helper method of `BasicController`be to much? There is one for `getIdentity`.)
2. Put a safety net around the `getRoles` call. I have seen situations before login, where there is a valid session but the roles can't be retrieved. OpenOlat dies painfully with a NullPointerException.