### PR TITLE
Fix CSS typos & remove property unknown to w3c

### DIFF
--- a/src/main/webapp/static/themes/light/modules/_qti21.scss
+++ b/src/main/webapp/static/themes/light/modules/_qti21.scss
@@ -63,7 +63,6 @@ ul.sessionControl {
 
 .sketch, .sketch>canvas {
 	touch-action: none;
-	user-drag: none;
 	-webkit-user-drag: none;
 	user-select: none;
 	-moz-user-select: none;
@@ -1425,7 +1424,7 @@ ul.o_qti_statistics_answers li span.o_qti_statistics_answer {
 						margin: 0;
 						padding: 5px 10px 10px 5px;
 						border-top: 1px solid $panel-default-border;
-						broder-bottom: 1px solid $panel-default-border;
+						border-bottom: 1px solid $panel-default-border;
 						h4 {
 							font-size: 100%;
 							font-weight: bold;

--- a/src/main/webapp/static/themes/openolat/_openolat_theme.scss
+++ b/src/main/webapp/static/themes/openolat/_openolat_theme.scss
@@ -88,7 +88,6 @@
 			left: 500px;
 			width: 400px;
 			top: -30px;
-			width: 400xp;
 			position: absolute;
 			border-radius: 20px;
 		}


### PR DESCRIPTION
The W3C specifications define the valid CSS properties. Only the official and browser-specific properties should be used to get the expected impact in the final rendering.

`user-drag` is no official property. `xp` and `broder` seem to be obvious typos.