### PR TITLE
Refactor checkContent helper to isSafeHtml of LocalFolderImpl

### DIFF
--- a/src/main/java/org/olat/core/commons/controllers/impressum/EmptyImpressumExtension.java
+++ b/src/main/java/org/olat/core/commons/controllers/impressum/EmptyImpressumExtension.java
@@ -19,38 +19,22 @@
  */
 package org.olat.core.commons.controllers.impressum;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.FileUtils;
 import org.olat.core.extensions.ExtensionElement;
-import org.olat.core.extensions.action.GenericActionExtension;
 import org.olat.core.gui.UserRequest;
 import org.olat.core.gui.control.Controller;
 import org.olat.core.gui.control.WindowControl;
-import org.olat.core.util.filter.FilterFactory;
 import org.olat.core.util.i18n.I18nModule;
-import org.olat.core.util.vfs.LocalFileImpl;
 import org.olat.core.util.vfs.LocalFolderImpl;
-import org.olat.core.util.vfs.VFSContainer;
-import org.olat.core.util.vfs.VFSItem;
-import org.olat.core.util.vfs.VFSLeaf;
 
 /* 
  * Initial date: 12 Apr 2020<br>
  * @author aboeckle, alexander.boeckle@frentix.com
  */
-public class EmptyImpressumExtension extends GenericActionExtension {
-	
-	private final ImpressumModule impressumModule;
-	private final I18nModule i18nModule;
-	
+public class EmptyImpressumExtension extends GenericImpressumExtension {
+
 	public EmptyImpressumExtension(ImpressumModule impressumModule, I18nModule i18nModule) {
-		this.impressumModule = impressumModule;
-		this.i18nModule = i18nModule;
+		super(impressumModule, i18nModule);
 	}
-	
 
 	@Override
 	public Controller createController(UserRequest ureq, WindowControl wControl, Object arg) {
@@ -65,70 +49,25 @@ public class EmptyImpressumExtension extends GenericActionExtension {
 		
 		// Second check: Impressum module
 		if (impressumModule.isEnabled()) {
-			VFSContainer impressumDir = new LocalFolderImpl(impressumModule.getImpressumDirectory());
-			VFSContainer termsOfUseDir = new LocalFolderImpl(impressumModule.getTermsOfUseDirectory());
-			VFSContainer privacyPoliciyDir = new LocalFolderImpl(impressumModule.getPrivacyPolicyDirectory());
+			LocalFolderImpl impressumDir = new LocalFolderImpl(impressumModule.getImpressumDirectory());
+			LocalFolderImpl termsOfUseDir = new LocalFolderImpl(impressumModule.getTermsOfUseDirectory());
+			LocalFolderImpl privacyPoliciyDir = new LocalFolderImpl(impressumModule.getPrivacyPolicyDirectory());
 			
 			// First check the imprint 
-			enabled |= checkModule(impressumDir, ureq);
+			enabled |= isModuleEnabled(impressumDir, ureq);
 			
 			// Go on if enabled is false
 			// and check the terms of use
 			if (!enabled) {
-				enabled |= checkModule(termsOfUseDir, ureq);
+				enabled |= isModuleEnabled(termsOfUseDir, ureq);
 			}
 			
 			// Go on if enabled is still false
 			// and check the privacy policy
 			if (!enabled) {
-				enabled |= checkModule(privacyPoliciyDir, ureq);
+				enabled |= isModuleEnabled(privacyPoliciyDir, ureq);
 			}
 		}
-		
 		return enabled ? null : super.getExtensionFor(extensionPoint, ureq);
-	}
-	
-	private boolean checkContent(VFSItem file) {
-		boolean check = false;
-		if(file instanceof VFSLeaf && file.exists() ) {
-			if(file instanceof LocalFileImpl) {
-				File f = ((LocalFileImpl)file).getBasefile();
-				try {
-					String content = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
-					content = FilterFactory.getHtmlTagAndDescapingFilter().filter(content);
-					if(content.length() > 0) {
-						content = content.trim();
-					}
-					if(content.length() > 0) {
-						check = true;
-					}
-				} catch (IOException e) {
-					// Nothing to to here
-				}
-			} else {
-				check = true;
-			}
-		}
-		return check;
-	}
-	
-	private boolean checkModule(VFSContainer baseFolder, UserRequest ureq) {
-		boolean enabled = true;
-		
-		if (checkContent(baseFolder.resolve("index_" + ureq.getLocale().getLanguage() + ".html"))) {
-			// Nothing to do here
-		} else if (checkContent(baseFolder.resolve("index_" + I18nModule.getDefaultLocale().getLanguage() + ".html"))) {
-			// Nothing to do here
-		} else {
-			for (String locale : i18nModule.getEnabledLanguageKeys()) {
-				if (checkContent(baseFolder.resolve("index_" + locale + ".html"))) {
-					return enabled;
-				}
-			}
-			
-			enabled &= false;
-		} 
-		
-		return enabled;
 	}
 }

--- a/src/main/java/org/olat/core/commons/controllers/impressum/GenericImpressumExtension.java
+++ b/src/main/java/org/olat/core/commons/controllers/impressum/GenericImpressumExtension.java
@@ -19,10 +19,8 @@
  */
 package org.olat.core.commons.controllers.impressum;
 
-import org.olat.core.extensions.ExtensionElement;
+import org.olat.core.extensions.action.GenericActionExtension;
 import org.olat.core.gui.UserRequest;
-import org.olat.core.gui.control.Controller;
-import org.olat.core.gui.control.WindowControl;
 import org.olat.core.util.i18n.I18nModule;
 import org.olat.core.util.vfs.LocalFolderImpl;
 
@@ -30,25 +28,32 @@ import org.olat.core.util.vfs.LocalFolderImpl;
  * Initial date: 12 Apr 2020<br>
  * @author aboeckle, alexander.boeckle@frentix.com
  */
-public class PrivacyPolicyExtension extends GenericImpressumExtension {
+public class GenericImpressumExtension extends GenericActionExtension {
 
-	public PrivacyPolicyExtension(ImpressumModule impressumModule, I18nModule i18nModule) {
-		super(impressumModule, i18nModule);
+	protected final ImpressumModule impressumModule;
+	protected final I18nModule i18nModule;
+	private static final String INDEX_HTML = "index_%s.html";
+
+	public GenericImpressumExtension(ImpressumModule impressumModule, I18nModule i18nModule) {
+		this.impressumModule = impressumModule;
+		this.i18nModule = i18nModule;
 	}
 
-	@Override
-	public Controller createController(UserRequest ureq, WindowControl wControl, Object arg) {
-		return new PrivacyPolicyController(ureq, wControl);
-	}
-
-	@Override
-	public ExtensionElement getExtensionFor(String extensionPoint, UserRequest ureq) {
+	protected boolean isModuleEnabled(LocalFolderImpl baseFolder, UserRequest ureq) {
 		boolean enabled = false;
 		
-		if (impressumModule.isEnabled()) {
-			LocalFolderImpl impressumDir = new LocalFolderImpl(impressumModule.getPrivacyPolicyDirectory());
-			enabled = isModuleEnabled(impressumDir, ureq);
+		if (baseFolder.isSafeHtmlFile(String.format(INDEX_HTML, ureq.getLocale().getLanguage()))) {
+			enabled = true;
+		} else if (baseFolder.isSafeHtmlFile(String.format(INDEX_HTML, I18nModule.getDefaultLocale().getLanguage()))) {
+			enabled = true;
+		} else {
+			for (String locale : i18nModule.getEnabledLanguageKeys()) {
+				if (baseFolder.isSafeHtmlFile(String.format(INDEX_HTML, locale))) {
+					enabled = true;
+					break;
+				}
+			}
 		}
-		return enabled ? super.getExtensionFor(extensionPoint, ureq) : null;
+		return enabled;
 	}
 }

--- a/src/main/java/org/olat/core/commons/controllers/impressum/ImpressumController.java
+++ b/src/main/java/org/olat/core/commons/controllers/impressum/ImpressumController.java
@@ -46,6 +46,8 @@ public class ImpressumController extends BasicController {
 	@Autowired
 	private I18nModule i18nModule;
 
+	private static final String index_html = "index_%s.html";
+
 	/**
 	 * @param ureq
 	 * @param control
@@ -57,17 +59,17 @@ public class ImpressumController extends BasicController {
 		listenTo(iframe);
 		
 		String langCode = ureq.getLocale().getLanguage();
-		String fileName = "index_" + langCode + ".html";
+		String fileName = String.format(index_html, langCode);
 		if (new File (baseFolder, fileName).exists()){
 			iframe.setCurrentURI(fileName);
 		} else {
 			langCode = I18nModule.getDefaultLocale().getLanguage();
-			fileName = "index_" + langCode + ".html";
+			fileName = String.format(index_html, langCode);
 			if (new File(baseFolder, fileName).exists()) {
 				iframe.setCurrentURI(fileName);
 			} else {
 				for (String lang : i18nModule.getEnabledLanguageKeys()) {
-					fileName = "index_" + lang + ".html";
+					fileName = String.format(index_html, lang);
 					if (new File(baseFolder, fileName).exists()) {
 						iframe.setCurrentURI(fileName);
 						break;

--- a/src/main/java/org/olat/core/commons/controllers/impressum/ImpressumExtension.java
+++ b/src/main/java/org/olat/core/commons/controllers/impressum/ImpressumExtension.java
@@ -19,38 +19,22 @@
  */
 package org.olat.core.commons.controllers.impressum;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.FileUtils;
 import org.olat.core.extensions.ExtensionElement;
-import org.olat.core.extensions.action.GenericActionExtension;
 import org.olat.core.gui.UserRequest;
 import org.olat.core.gui.control.Controller;
 import org.olat.core.gui.control.WindowControl;
-import org.olat.core.util.filter.FilterFactory;
 import org.olat.core.util.i18n.I18nModule;
-import org.olat.core.util.vfs.LocalFileImpl;
 import org.olat.core.util.vfs.LocalFolderImpl;
-import org.olat.core.util.vfs.VFSContainer;
-import org.olat.core.util.vfs.VFSItem;
-import org.olat.core.util.vfs.VFSLeaf;
 
 /* 
  * Initial date: 12 Apr 2020<br>
  * @author aboeckle, alexander.boeckle@frentix.com
  */
-public class ImpressumExtension extends GenericActionExtension {
-	
-	private final ImpressumModule impressumModule;
-	private final I18nModule i18nModule;
-	
+public class ImpressumExtension extends GenericImpressumExtension {
+
 	public ImpressumExtension(ImpressumModule impressumModule, I18nModule i18nModule) {
-		this.impressumModule = impressumModule;
-		this.i18nModule = i18nModule;
+		super(impressumModule, i18nModule);
 	}
-	
 
 	@Override
 	public Controller createController(UserRequest ureq, WindowControl wControl, Object arg) {
@@ -59,51 +43,12 @@ public class ImpressumExtension extends GenericActionExtension {
 	
 	@Override
 	public ExtensionElement getExtensionFor(String extensionPoint, UserRequest ureq) {
-boolean enabled = false;
+		boolean enabled = false;
 		
 		if (impressumModule.isEnabled()) {
-			VFSContainer impressumDir = new LocalFolderImpl(impressumModule.getImpressumDirectory());
-			
-			if (checkContent(impressumDir.resolve("index_" + ureq.getLocale().getLanguage() + ".html"))) {
-				enabled |= true;
-			} else if (checkContent(impressumDir.resolve("index_" + I18nModule.getDefaultLocale().getLanguage() + ".html"))) {
-				enabled |= true;
-			} else {
-				
-				for (String locale : i18nModule.getEnabledLanguageKeys()) {
-					if (checkContent(impressumDir.resolve("index_" + locale + ".html"))) {
-						enabled |= true;
-						break;
-					}
-				}
-			} 
-				
+			LocalFolderImpl impressumDir = new LocalFolderImpl(impressumModule.getImpressumDirectory());
+			enabled = isModuleEnabled(impressumDir, ureq);
 		}
-		
 		return enabled ? super.getExtensionFor(extensionPoint, ureq) : null;
-	}
-	
-	private boolean checkContent(VFSItem file) {
-		boolean check = false;
-		if(file instanceof VFSLeaf && file.exists() ) {
-			if(file instanceof LocalFileImpl) {
-				File f = ((LocalFileImpl)file).getBasefile();
-				try {
-					String content = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
-					content = FilterFactory.getHtmlTagAndDescapingFilter().filter(content);
-					if(content.length() > 0) {
-						content = content.trim();
-					}
-					if(content.length() > 0) {
-						check = true;
-					}
-				} catch (IOException e) {
-					// Nothing to to here
-				}
-			} else {
-				check = true;
-			}
-		}
-		return check;
 	}
 }

--- a/src/main/java/org/olat/core/commons/controllers/impressum/TermsOfUseExtension.java
+++ b/src/main/java/org/olat/core/commons/controllers/impressum/TermsOfUseExtension.java
@@ -19,39 +19,22 @@
  */
 package org.olat.core.commons.controllers.impressum;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.FileUtils;
 import org.olat.core.extensions.ExtensionElement;
-import org.olat.core.extensions.action.GenericActionExtension;
 import org.olat.core.gui.UserRequest;
 import org.olat.core.gui.control.Controller;
 import org.olat.core.gui.control.WindowControl;
-import org.olat.core.util.filter.FilterFactory;
 import org.olat.core.util.i18n.I18nModule;
-import org.olat.core.util.vfs.LocalFileImpl;
 import org.olat.core.util.vfs.LocalFolderImpl;
-import org.olat.core.util.vfs.VFSContainer;
-import org.olat.core.util.vfs.VFSItem;
-import org.olat.core.util.vfs.VFSLeaf;
 
 /* 
  * Initial date: 12 Apr 2020<br>
  * @author aboeckle, alexander.boeckle@frentix.com
  */
-public class TermsOfUseExtension extends GenericActionExtension {
+public class TermsOfUseExtension extends GenericImpressumExtension {
 
-	
-	private final ImpressumModule impressumModule;
-	private final I18nModule i18nModule;
-	
 	public TermsOfUseExtension(ImpressumModule impressumModule, I18nModule i18nModule) {
-		this.impressumModule = impressumModule;
-		this.i18nModule = i18nModule;
+		super(impressumModule, i18nModule);
 	}
-	
 
 	@Override
 	public Controller createController(UserRequest ureq, WindowControl wControl, Object arg) {
@@ -61,49 +44,10 @@ public class TermsOfUseExtension extends GenericActionExtension {
 	@Override
 	public ExtensionElement getExtensionFor(String extensionPoint, UserRequest ureq) {
 		boolean enabled = false;
-		
 		if (impressumModule.isEnabled()) {
-			VFSContainer impressumDir = new LocalFolderImpl(impressumModule.getTermsOfUseDirectory());
-			
-			if (checkContent(impressumDir.resolve("index_" + ureq.getLocale().getLanguage() + ".html"))) {
-				enabled |= true;
-			} else if (checkContent(impressumDir.resolve("index_" + I18nModule.getDefaultLocale().getLanguage() + ".html"))) {
-				enabled |= true;
-			} else {
-				for (String locale : i18nModule.getEnabledLanguageKeys()) {
-					if (checkContent(impressumDir.resolve("index_" + locale + ".html"))) {
-						enabled |= true;
-						break;
-					}
-				}
-			} 
-				
+			LocalFolderImpl impressumDir = new LocalFolderImpl(impressumModule.getTermsOfUseDirectory());
+			enabled = isModuleEnabled(impressumDir, ureq);
 		}
-		
 		return enabled ? super.getExtensionFor(extensionPoint, ureq) : null;
-	}
-	
-	private boolean checkContent(VFSItem file) {
-		boolean check = false;
-		if(file instanceof VFSLeaf && file.exists() ) {
-			if(file instanceof LocalFileImpl) {
-				File f = ((LocalFileImpl)file).getBasefile();
-				try {
-					String content = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
-					content = FilterFactory.getHtmlTagAndDescapingFilter().filter(content);
-					if(content.length() > 0) {
-						content = content.trim();
-					}
-					if(content.length() > 0) {
-						check = true;
-					}
-				} catch (IOException e) {
-					// Nothing to to here
-				}
-			} else {
-				check = true;
-			}
-		}
-		return check;
 	}
 }

--- a/src/main/java/org/olat/core/util/vfs/LocalFolderImpl.java
+++ b/src/main/java/org/olat/core/util/vfs/LocalFolderImpl.java
@@ -29,6 +29,7 @@ package org.olat.core.util.vfs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,6 +48,7 @@ import org.olat.core.logging.AssertException;
 import org.olat.core.logging.Tracing;
 import org.olat.core.logging.activity.ThreadLocalUserActivityLogger;
 import org.olat.core.util.FileUtils;
+import org.olat.core.util.filter.FilterFactory;
 import org.olat.core.util.vfs.filters.VFSItemFilter;
 import org.olat.core.util.vfs.filters.VFSSystemItemFilter;
 import org.olat.core.util.vfs.filters.VFSVersionsItemFilter;
@@ -390,5 +392,35 @@ public class LocalFolderImpl extends LocalImpl implements VFSContainer {
 	@Override
 	public VFSItemFilter getDefaultItemFilter() {
 		return defaultFilter;
+	}
+
+	public boolean isSafeHtmlFile(String filename) {
+		boolean check = false;
+		VFSItem file = resolve(filename);
+		if (!(file instanceof LocalFileImpl)) {
+			// we are not even a file
+			return false;
+		} else {
+			String content;
+			File f = ((LocalFileImpl) file).getBasefile();
+			try {
+				if (org.apache.commons.io.FileUtils.directoryContains(getBasefile(), f)) {
+					content = org.apache.commons.io.FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+					content = FilterFactory.getHtmlTagAndDescapingFilter().filter(content);
+				} else {
+					content = "";
+				}
+				if (content.length() > 0) {
+					content = content.trim();
+				}
+				if (content.length() > 0) {
+					check = true;
+				}
+			} catch (IOException e) {
+				// Nothing to to here
+			}
+
+		}
+		return check;
 	}
 }

--- a/src/test/java/org/olat/admin/layout/LayoutModuleTest.java
+++ b/src/test/java/org/olat/admin/layout/LayoutModuleTest.java
@@ -1,0 +1,84 @@
+package org.olat.admin.layout;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.olat.test.OlatTestCase;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class LayoutModuleTest extends OlatTestCase {
+
+    @Autowired
+    private LayoutModule layoutModule;
+
+    @Test
+    public void getConfigProperty() {
+        String expected = "my-logo.svg";
+        layoutModule.setLogoFilename(expected);
+        String provided = layoutModule.getConfigProperty("logo.filename");
+        assertThat(provided).isEqualTo(expected);
+    }
+
+    @Test
+    public void removeLogo() throws IOException {
+        layoutModule.setLogoFilename("new-logo.svg");
+        File logo = layoutModule.getLogo();
+        File dir = layoutModule.getLogoDirectory();
+
+        layoutModule.removeLogo();
+        assertThat(FileUtils.directoryContains(dir, logo)).isFalse();
+        assertThat(layoutModule.getLogoFilename()).isNullOrEmpty();
+    }
+
+    @Test
+    public void getLogoUri() {
+        assertThat(layoutModule.getLogoUri()).isEqualTo("/g/logo/oo-logo@1x.png");
+    }
+
+    @Test
+    public void getLogoAlt() {
+        String provided = "unittest alt";
+        layoutModule.setLogoAlt(provided);
+        assertThat(layoutModule.getLogoAlt()).isEqualTo(provided);
+    }
+
+    @Test
+    public void getLogoLinkType() {
+        String provided = "unittest link type";
+        layoutModule.setLogoLinkType(provided);
+        assertThat(layoutModule.getLogoLinkType()).isEqualTo(provided);
+    }
+
+    @Test
+    public void getFooterLinkUri() {
+        String provided = "unittest link uri";
+        layoutModule.setFooterLinkUri(provided);
+        assertThat(layoutModule.getFooterLinkUri()).isEqualTo(provided);
+    }
+
+    @Test
+    public void getFooterLine() {
+        String provided = "unittest footer line";
+        layoutModule.setFooterLine(provided);
+        assertThat(layoutModule.getFooterLine()).isEqualTo(provided);
+    }
+
+    @Test
+    public void getLogoLinkUri() {
+        String provided = "unittest link uri";
+        layoutModule.setLogoLinkUri(provided);
+        assertThat(layoutModule.getFooterLinkUri()).isEqualTo(provided);
+    }
+
+
+    @Test
+    public void getLogo_empty() {
+        layoutModule.setLogoFilename(" ");
+        assertThat(layoutModule.getLogo()).isNull();
+    }
+
+}

--- a/src/test/java/org/olat/core/commons/controllers/impressum/EmptyImpressumExtensionTest.java
+++ b/src/test/java/org/olat/core/commons/controllers/impressum/EmptyImpressumExtensionTest.java
@@ -1,0 +1,60 @@
+package org.olat.core.commons.controllers.impressum;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.olat.core.extensions.ExtensionElement;
+import org.olat.core.gui.util.SyntheticUserRequest;
+import org.olat.core.util.FileUtils;
+import org.olat.core.util.WebappHelper;
+import org.olat.test.OlatTestCase;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class EmptyImpressumExtensionTest extends OlatTestCase {
+
+    @Autowired
+    ImpressumModule impressumModule;
+
+    @Autowired
+    EmptyImpressumExtension emptyImpressumExtension;
+
+    Path indexEnHtml;
+    boolean currentImpressumEnabled;
+    Path customizingImpressum;
+
+    @Before
+    public void setUp() throws IOException {
+        currentImpressumEnabled = impressumModule.isEnabled();
+        impressumModule.setEnabled(true);
+        customizingImpressum = Paths.get(WebappHelper.getUserDataRoot(), "customizing", "impressum");
+        customizingImpressum.toFile().mkdirs();
+        indexEnHtml = customizingImpressum.resolve("index_de.html");
+        Path file = Files.createFile(indexEnHtml);
+        String content = "<div>Hallo Impressum</div>";
+        Files.write( file, content.getBytes());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirsAndFiles(customizingImpressum);
+        impressumModule.setEnabled(currentImpressumEnabled);
+    }
+
+    @Test
+    public void getExtensionFor() {
+        SyntheticUserRequest ureq = new SyntheticUserRequest(null, Locale.ENGLISH);
+        ExtensionElement extElem = emptyImpressumExtension.getExtensionFor(
+                "org.olat.core.commons.controllers.impressum.ImpressumMainController", ureq);
+        assertThat(extElem).isNull();
+    }
+
+}

--- a/src/test/java/org/olat/core/commons/controllers/impressum/ImpressumExtensionTest.java
+++ b/src/test/java/org/olat/core/commons/controllers/impressum/ImpressumExtensionTest.java
@@ -1,0 +1,89 @@
+package org.olat.core.commons.controllers.impressum;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.olat.core.extensions.ExtensionElement;
+import org.olat.core.gui.control.Controller;
+import org.olat.core.gui.control.WindowControl;
+import org.olat.core.gui.util.SyntheticUserRequest;
+import org.olat.core.gui.util.WindowControlMocker;
+import org.olat.core.util.FileUtils;
+import org.olat.core.util.WebappHelper;
+import org.olat.test.OlatTestCase;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ImpressumExtensionTest extends OlatTestCase {
+
+    @Autowired
+    ImpressumModule impressumModule;
+
+    @Autowired
+    ImpressumExtension impressumExtension;
+
+    boolean currentImpressumEnabled;
+    Path customizingImpressum;
+
+    @Before
+    public void setUp() throws IOException {
+        currentImpressumEnabled = impressumModule.isEnabled();
+        impressumModule.setEnabled(true);
+        customizingImpressum = Paths.get(WebappHelper.getUserDataRoot(), "customizing", "impressum");
+        customizingImpressum.toFile().mkdirs();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirsAndFiles(customizingImpressum);
+        impressumModule.setEnabled(currentImpressumEnabled);
+    }
+
+    @Test
+    public void getExtensionFor() throws IOException {
+        Path indexHtml = createImpressumFile("en", "<div>Hello Impressum</div>");
+        SyntheticUserRequest ureq = new SyntheticUserRequest(null, Locale.ENGLISH);
+        ExtensionElement extElem = impressumExtension.getExtensionFor(
+                "org.olat.core.commons.controllers.impressum.ImpressumMainController", ureq);
+        assertThat(extElem).isInstanceOf(ImpressumExtension.class);
+        Files.deleteIfExists(indexHtml);
+    }
+
+    @Test
+    public void getExtensionFor_NotEven_A_File() throws IOException {
+        Path indexEnHtml = customizingImpressum.resolve("index_en.html");
+        indexEnHtml.toFile().mkdirs();
+
+        SyntheticUserRequest ureq = new SyntheticUserRequest(null, Locale.ENGLISH);
+        ExtensionElement extElem = impressumExtension.getExtensionFor(
+                "org.olat.core.commons.controllers.impressum.ImpressumMainController", ureq);
+        assertThat(extElem).isNull();
+        Files.deleteIfExists(indexEnHtml);
+    }
+
+    @Test
+    public void getExtensionFor_Malicious() throws IOException {
+        Path indexHtml = createImpressumFile("de", "<script>alert('bad!');</script>");
+        SyntheticUserRequest ureq = new SyntheticUserRequest(null, Locale.ENGLISH);
+        ExtensionElement extElem = impressumExtension.getExtensionFor(
+                "org.olat.core.commons.controllers.impressum.ImpressumMainController", ureq);
+        assertThat(extElem).isNull();
+        Files.deleteIfExists(indexHtml);
+    }
+    
+    private Path createImpressumFile(String langCode, String content) throws IOException {
+        String filename = String.format("index_%s.html", langCode);
+        Path indexHtml = customizingImpressum.resolve(filename);
+        Path file = Files.createFile(indexHtml);
+        Files.write(file, content.getBytes());
+        return indexHtml;
+    }
+}

--- a/src/test/java/org/olat/test/AllTestsJunit4.java
+++ b/src/test/java/org/olat/test/AllTestsJunit4.java
@@ -43,6 +43,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	org.olat.admin.layout.LayoutModuleTest.class,
 	org.olat.core.util.i18n.I18nTest.class,
 	// org.olat.core.util.mail.MailTest.class, // redisabled since mails are sent despite the fact that the whitelist is enabled
 	org.olat.core.gui.components.table.MultiSelectColumnDescriptorTest.class,
@@ -50,6 +51,8 @@ import org.junit.runners.Suite;
 	org.olat.core.gui.components.table.TableMultiSelectEventTest.class,
 	org.olat.core.gui.components.table.SorterTest.class,
 	org.olat.core.commons.chiefcontrollers.ChiefControllerMessageEventTest.class,
+	org.olat.core.commons.controllers.impressum.EmptyImpressumExtensionTest.class,
+	org.olat.core.commons.controllers.impressum.ImpressumExtensionTest.class,
 	org.olat.core.util.vfs.VFSTest.class,
 	org.olat.core.util.vfs.VFSManagerTest.class,
 	org.olat.core.util.filter.impl.XSSFilterParamTest.class,


### PR DESCRIPTION
This PR does 3 things:

1. Fix 2 occurences of the path injection vulnerability (see https://rules.sonarsource.com/java/tag/owasp/RSPEC-2083 )
2. Refactor code a bit to remove duplicate code
3. Adds some tests to proove refactoring keeps functionality.

I wonder if the `isModuleEnabled`-method should only check for

```java
for (String locale : i18nModule.getEnabledLanguageKeys()) {
    if (baseFolder.isSafeHtmlFile(String.format(index_html, locale))) {
        enabled = true;
	break;
    }
}
```
This might be *slightly* less efficient but is **far** more readable and the method would not need the UserRequest. What do others think?